### PR TITLE
Update the repository to be compatible with modern Node.js versions.

### DIFF
--- a/lib/asn1/univ.js
+++ b/lib/asn1/univ.js
@@ -211,7 +211,7 @@ Enumerate.prototype.encode = function(encoder) {
  */
 function OctetString(value) {
 	spec.Asn1Spec.call(this, new spec.Asn1Tag(spec.TagClass.Universal, spec.TagFormat.Primitive, UniversalTag.OctetString));
-	this.value = value || new Buffer(0);
+	this.value = value || Buffer.alloc(0);
 }
 
 inherits(OctetString, spec.Asn1Spec);
@@ -241,7 +241,7 @@ OctetString.prototype.encode = function(encoder) {
  */
 function ObjectIdentifier(value) {
 	spec.Asn1Spec.call(this, new spec.Asn1Tag(spec.TagClass.Universal, spec.TagFormat.Primitive, UniversalTag.ObjectIdentifier));
-	this.value = value || new Buffer(5);
+	this.value = value || Buffer.alloc(5);
 }
 
 inherits(ObjectIdentifier, spec.Asn1Spec);

--- a/lib/core/rle.js
+++ b/lib/core/rle.js
@@ -2434,7 +2434,7 @@ function copyTempDouble(ptr) {
           }
         },read:function (stream, buffer, offset, length, position) {
           // FIXME this is terrible.
-          var nbuffer = new Buffer(length);
+          var nbuffer = Buffer.alloc(length);
           var res;
           try {
             res = fs.readSync(stream.nfd, nbuffer, 0, length, position);
@@ -2449,7 +2449,7 @@ function copyTempDouble(ptr) {
           return res;
         },write:function (stream, buffer, offset, length, position) {
           // FIXME this is terrible.
-          var nbuffer = new Buffer(buffer.subarray(offset, offset + length));
+          var nbuffer = Buffer.from(buffer.subarray(offset, offset + length));
           var res;
           try {
             res = fs.writeSync(stream.nfd, nbuffer, 0, length, position);

--- a/lib/core/type.js
+++ b/lib/core/type.js
@@ -32,7 +32,7 @@ function Stream(i) {
 		this.buffer = i;
 	}
 	else {
-		this.buffer = new Buffer(i || 8192);
+		this.buffer = Buffer.alloc(i || 8192);
 	}
 }
 
@@ -397,7 +397,7 @@ inherits(UInt32Be, SingleType);
  */
 function BinaryString(value, opt) {
 	Type.call(this, opt);
-	this.value = value || new Buffer("");
+	this.value = value || Buffer.from("");
 }
 
 //inherit from type

--- a/lib/protocol/cert.js
+++ b/lib/protocol/cert.js
@@ -51,7 +51,7 @@ function rsaPublicKey(opt) {
         modulus : new type.BinaryString(null, { readLength : new type.CallableValue(function() {
         	return self.keylen.value - 8;
         }) }),
-        padding : new type.BinaryString(new Buffer(Array(8 + 1).join('\x00')), { readLength : new type.CallableValue(8) })
+        padding : new type.BinaryString(Buffer.alloc(8), { readLength : new type.CallableValue(8) })
 	};
 	
 	return new type.Component(self, opt);

--- a/lib/protocol/pdu/caps.js
+++ b/lib/protocol/pdu/caps.js
@@ -265,7 +265,7 @@ function orderCapability(orders, opt) {
 	
 	var self = {
 		__TYPE__ : CapsType.CAPSTYPE_ORDER,
-		terminalDescriptor : new type.BinaryString(new Buffer(Array(16 + 1).join('\x00'), 'binary'), {readLength : new type.CallableValue(16)}),
+		terminalDescriptor : new type.BinaryString(Buffer.alloc(16, 'binary'), {readLength : new type.CallableValue(16)}),
         pad4octetsA : new type.UInt32Le(0),
         desktopSaveXGranularity : new type.UInt16Le(1),
         desktopSaveYGranularity : new type.UInt16Le(20),
@@ -353,7 +353,7 @@ function inputCapability(opt) {
         // same value as gcc.ClientCoreSettings.keyboardFnKeys
         keyboardFunctionKey : new type.UInt32Le(),
         // same value as gcc.ClientCoreSettingrrs.imeFileName
-        imeFileName : new type.BinaryString(new Buffer(Array(64 + 1).join('\x00'), 'binary'), {readLength : new type.CallableValue(64)})
+        imeFileName : new type.BinaryString(Buffer.alloc(64, 'binary'), {readLength : new type.CallableValue(64)})
 	};
 	
 	return new type.Component(self, opt);

--- a/lib/protocol/pdu/data.js
+++ b/lib/protocol/pdu/data.js
@@ -389,7 +389,7 @@ function demandActivePDU(capabilities, opt) {
         lengthCombinedCapabilities : new type.UInt16Le(function() {
         	return self.numberCapabilities.size() + self.pad2Octets.size() + self.capabilitySets.size();
         }),
-        sourceDescriptor : new type.BinaryString(new Buffer('node-rdpjs', 'binary'), { readLength : new type.CallableValue(function() {
+        sourceDescriptor : new type.BinaryString(Buffer.from('node-rdpjs', 'binary'), { readLength : new type.CallableValue(function() {
         	return self.lengthSourceDescriptor.value
         }) }),
         numberCapabilities : new type.UInt16Le(function() {
@@ -426,7 +426,7 @@ function confirmActivePDU(capabilities, shareId, opt) {
         lengthCombinedCapabilities : new type.UInt16Le(function() {
         	return self.numberCapabilities.size() + self.pad2Octets.size() + self.capabilitySets.size();
         }),
-        sourceDescriptor : new type.BinaryString(new Buffer('rdpy', 'binary'), { readLength : new type.CallableValue(function() {
+        sourceDescriptor : new type.BinaryString(Buffer.from('rdpy', 'binary'), { readLength : new type.CallableValue(function() {
         	return self.lengthSourceDescriptor.value
         }) }),
         numberCapabilities : new type.UInt16Le(function() {
@@ -456,7 +456,7 @@ function deactiveAllPDU(opt) {
         lengthSourceDescriptor : new type.UInt16Le(function() {
         	return self.sourceDescriptor.size();
         }),
-        sourceDescriptor : new type.BinaryString(new Buffer('rdpy', 'binary'), { readLength : new type.CallableValue(function() {
+        sourceDescriptor : new type.BinaryString(Buffer.from('rdpy', 'binary'), { readLength : new type.CallableValue(function() {
         	self.lengthSourceDescriptor 
         }) })
 	};

--- a/lib/protocol/pdu/lic.js
+++ b/lib/protocol/pdu/lic.js
@@ -127,14 +127,14 @@ function productInformation() {
         	return self.pbCompanyName.size();
         }),
         // may contain "Microsoft Corporation" from server microsoft
-        pbCompanyName : new type.BinaryString(new Buffer('Microsoft Corporation', 'ucs2'), { readLength : new type.CallableValue(function() {
+        pbCompanyName : new type.BinaryString(Buffer.from('Microsoft Corporation', 'ucs2'), { readLength : new type.CallableValue(function() {
         	return self.cbCompanyName.value;
         })}),
         cbProductId : new type.UInt32Le(function() {
         	return self.pbProductId.size();
         }),
         // may contain "A02" from microsoft license server
-        pbProductId : new type.BinaryString(new Buffer('A02', 'ucs2'), { readLength : new type.CallableValue(function() {
+        pbProductId : new type.BinaryString(Buffer.from('A02', 'ucs2'), { readLength : new type.CallableValue(function() {
         	return self.cbProductId.value;
         })})
 	};
@@ -183,7 +183,7 @@ function scopeList() {
 function serverLicenseRequest(opt) {
 	var self = {
 		__TYPE__ : MessageType.LICENSE_REQUEST,
-		serverRandom : new type.BinaryString(new Buffer(Array(32 + 1).join('\x00')), { readLength : new type.CallableValue(32) } ),
+		serverRandom : new type.BinaryString(Buffer.alloc(32), { readLength : new type.CallableValue(32) } ),
         productInfo : productInformation(),
         keyExchangeList : licenseBinaryBlob(BinaryBlobType.BB_KEY_EXCHG_ALG_BLOB),
         serverCertificate : licenseBinaryBlob(BinaryBlobType.BB_CERTIFICATE_BLOB),
@@ -205,7 +205,7 @@ function clientNewLicenseRequest(opt) {
         // pure microsoft client ;-)
         // http://msdn.microsoft.com/en-us/library/1040af38-c733-4fb3-acd1-8db8cc979eda#id10
         platformId : new type.UInt32Le(0x04000000 | 0x00010000),
-        clientRandom : new type.BinaryString(new Buffer(Array(32 + 1).join('\x00')), { readLength : new type.CallableValue(32) }),
+        clientRandom : new type.BinaryString(Buffer.alloc(32), { readLength : new type.CallableValue(32) }),
         encryptedPreMasterSecret : licenseBinaryBlob(BinaryBlobType.BB_RANDOM_BLOB),
         ClientUserName : licenseBinaryBlob(BinaryBlobType.BB_CLIENT_USER_NAME_BLOB),
         ClientMachineName : licenseBinaryBlob(BinaryBlobType.BB_CLIENT_MACHINE_NAME_BLOB)
@@ -224,7 +224,7 @@ function serverPlatformChallenge(opt) {
 		__TYPE__ : MessageType.PLATFORM_CHALLENGE,
 		connectFlags : new type.UInt32Le(),
         encryptedPlatformChallenge : licenseBinaryBlob(BinaryBlobType.BB_ANY_BLOB),
-        MACData : new type.BinaryString(new Buffer(Array(16 + 1).join('\x00')), { readLength : new type.CallableValue(16) })
+        MACData : new type.BinaryString(Buffer.alloc(16), { readLength : new type.CallableValue(16) })
 	};
 	
 	return new type.Component(self, opt);
@@ -240,7 +240,7 @@ function clientPLatformChallengeResponse(opt) {
 		__TYPE__ : MessageType.PLATFORM_CHALLENGE_RESPONSE,
 		encryptedPlatformChallengeResponse : licenseBinaryBlob(BinaryBlobType.BB_DATA_BLOB),
         encryptedHWID : licenseBinaryBlob(BinaryBlobType.BB_DATA_BLOB),
-        MACData : new type.BinaryString(new Buffer(Array(16 + 1).join('\x00'), 'binary'), { readLength : new type.CallableValue(16) })
+        MACData : new type.BinaryString(Buffer.alloc(16, 'binary'), { readLength : new type.CallableValue(16) })
 	};
 	
 	return new type.Component(self, opt);

--- a/lib/protocol/pdu/sec.js
+++ b/lib/protocol/pdu/sec.js
@@ -142,11 +142,11 @@ function finalHash (key, random1, random2) {
  * @returns {Buffer}
  */
 function masterSecret (secret, random1, random2) {
-	var sh1 = saltedHash(new Buffer('A'), secret, random1, random2);
-	var sh2 = saltedHash(new Buffer('BB'), secret, random1, random2);
-	var sh3 = saltedHash(new Buffer('CCC'), secret, random1, random2);
+	var sh1 = saltedHash(Buffer.from('A'), secret, random1, random2);
+	var sh2 = saltedHash(Buffer.from('BB'), secret, random1, random2);
+	var sh3 = saltedHash(Buffer.from('CCC'), secret, random1, random2);
 	
-	var ms = new Buffer(sh1.length + sh2.length + sh3.length);
+	var ms = Buffer.alloc(sh1.length + sh2.length + sh3.length);
 	sh1.copy(ms);
 	sh2.copy(ms, sh1.length);
 	sh3.copy(ms, sh1.length + sh2.length);
@@ -160,10 +160,10 @@ function masterSecret (secret, random1, random2) {
  * @returns {Buffer}
  */
 function macData(macSaltKey, data) {
-	var salt1 = new Buffer(40);
+	var salt1 = Buffer.alloc(40);
 	salt1.fill(0x36);
 	
-	var salt2 = new Buffer(48);
+	var salt2 = Buffer.alloc(48);
 	salt2.fill(0x5c);
 
 	var dataLength = new type.UInt32Le(data.length).toStream().buffer;
@@ -207,19 +207,19 @@ function rdpInfos(extendedInfoConditional) {
         cbWorkingDir : new type.UInt16Le(function() {
         	return self.workingDir.size() - 2;
         }),
-        domain : new type.BinaryString(new Buffer('\x00', 'ucs2'),{ readLength : new type.CallableValue(function() {
+        domain : new type.BinaryString(Buffer.from('\x00', 'ucs2'),{ readLength : new type.CallableValue(function() {
         	return self.cbDomain.value + 2;
         })}),
-        userName : new type.BinaryString(new Buffer('\x00', 'ucs2'), { readLength : new type.CallableValue(function() {
+        userName : new type.BinaryString(Buffer.from('\x00', 'ucs2'), { readLength : new type.CallableValue(function() {
         	return self.cbUserName.value + 2;
         })}),
-        password : new type.BinaryString(new Buffer('\x00', 'ucs2'), { readLength : new type.CallableValue(function () {
+        password : new type.BinaryString(Buffer.from('\x00', 'ucs2'), { readLength : new type.CallableValue(function () {
         	return self.cbPassword.value + 2;
         })}),
-        alternateShell : new type.BinaryString(new Buffer('\x00', 'ucs2'), { readLength : new type.CallableValue(function() {
+        alternateShell : new type.BinaryString(Buffer.from('\x00', 'ucs2'), { readLength : new type.CallableValue(function() {
         	return self.cbAlternateShell.value + 2;
         })}),
-        workingDir : new type.BinaryString(new Buffer('\x00', 'ucs2'), { readLength : new type.CallableValue(function() {
+        workingDir : new type.BinaryString(Buffer.from('\x00', 'ucs2'), { readLength : new type.CallableValue(function() {
         	return self.cbWorkingDir.value + 2;
         })}),
         extendedInfo : rdpExtendedInfos({ conditional : extendedInfoConditional })
@@ -239,16 +239,16 @@ function rdpExtendedInfos(opt) {
 	    cbClientAddress : new type.UInt16Le(function() {
         	return self.clientAddress.size();
         }),
-	    clientAddress : new type.BinaryString(new Buffer('\x00', 'ucs2'),{ readLength : new type.CallableValue(function() {
+	    clientAddress : new type.BinaryString(Buffer.from('\x00', 'ucs2'),{ readLength : new type.CallableValue(function() {
 	    	return self.cbClientAddress;
 	    }) }),
 	    cbClientDir : new type.UInt16Le(function() {
         	return self.clientDir.size();
         }),
-	    clientDir : new type.BinaryString(new Buffer('\x00', 'ucs2'), { readLength : new type.CallableValue(function() {
+	    clientDir : new type.BinaryString(Buffer.from('\x00', 'ucs2'), { readLength : new type.CallableValue(function() {
 	    	return self.cbClientDir;
 	    }) }),
-	    clientTimeZone : new type.BinaryString(new Buffer(Array(172 + 1).join("\x00"))),
+	    clientTimeZone : new type.BinaryString(Buffer.alloc(172)),
 	    clientSessionId : new type.UInt32Le(),
 	    performanceFlags : new type.UInt32Le()
 	};
@@ -399,7 +399,7 @@ Client.prototype.sendInfoPkt = function() {
 };
 
 function reverse(buffer) {
-	var result = new Buffer(buffer.length);
+	var result = Buffer.alloc(buffer.length);
 	for(var i = 0; i < buffer.length; i++) {
 		result.writeUInt8(buffer.readUInt8(buffer.length - 1 - i), i);
 	}
@@ -431,13 +431,13 @@ Client.prototype.sendClientNewLicenseRequest = function(licenseRequest) {
 	request.obj.clientRandom.value = clientRandom;
 	
 	var preMasterSecretEncrypted = reverse(rsa.encrypt(reverse(preMasterSecret), publicKey));
-	var preMasterSecretEncryptedPadded = new Buffer(preMasterSecretEncrypted.length + 8);
+	var preMasterSecretEncryptedPadded = Buffer.alloc(preMasterSecretEncrypted.length + 8);
 	preMasterSecretEncryptedPadded.fill(0);
 	preMasterSecretEncrypted.copy(preMasterSecretEncryptedPadded);
 	request.obj.encryptedPreMasterSecret.obj.blobData.value = preMasterSecretEncryptedPadded;
 	
 	request.obj.ClientMachineName.obj.blobData.value = this.infos.obj.userName.value;
-	request.obj.ClientUserName.obj.blobData.value = new Buffer(this.machineName + '\x00');
+	request.obj.ClientUserName.obj.blobData.value = Buffer.from(this.machineName + '\x00');
 	
 	this.sendFlagged(SecurityFlag.SEC_LICENSE_PKT, lic.licensePacket(request));
 };
@@ -460,7 +460,7 @@ Client.prototype.sendClientChallengeResponse = function(platformChallenge) {
 	response.obj.encryptedPlatformChallengeResponse.obj.blobData.value = serverEncryptedChallenge;
 	response.obj.encryptedHWID.obj.blobData.value = crypto.createCipheriv('rc4', this.licenseKey, '').update(hwid);
 	
-	var sig = new Buffer(serverChallenge.length + hwid.length);
+	var sig = Buffer.alloc(serverChallenge.length + hwid.length);
 	serverChallenge.copy(sig);
 	hwid.copy(sig, serverChallenge.length);
 	response.obj.MACData.value = macData(this.licenseMacSalt, sig);

--- a/lib/protocol/rdp.js
+++ b/lib/protocol/rdp.js
@@ -94,13 +94,13 @@ function RdpClient(config) {
 	
 	// credentials
 	if (config.domain) {
-		this.sec.infos.obj.domain.value = new Buffer(config.domain + '\x00', 'ucs2');
+		this.sec.infos.obj.domain.value = Buffer.from(config.domain + '\x00', 'ucs2');
 	}
 	if (config.userName) {
-		this.sec.infos.obj.userName.value = new Buffer(config.userName + '\x00', 'ucs2');
+		this.sec.infos.obj.userName.value = Buffer.from(config.userName + '\x00', 'ucs2');
 	}
 	if (config.password) {
-		this.sec.infos.obj.password.value = new Buffer(config.password + '\x00', 'ucs2');
+		this.sec.infos.obj.password.value = Buffer.from(config.password + '\x00', 'ucs2');
 	}
 	
 	if (config.enablePerf) {

--- a/lib/protocol/t125/gcc.js
+++ b/lib/protocol/t125/gcc.js
@@ -270,18 +270,18 @@ function clientCoreData(opt) {
 		sasSequence : new type.UInt16Le(Sequence.RNS_UD_SAS_DEL),
 		kbdLayout : new type.UInt32Le(KeyboardLayout.FRENCH),
 		clientBuild : new type.UInt32Le(3790),
-		clientName : new type.BinaryString(new Buffer('node-rdpjs\x00\x00\x00\x00\x00\x00', 'ucs2'), { readLength : new type.CallableValue(32) }),
+		clientName : new type.BinaryString(Buffer.from('node-rdpjs\x00\x00\x00\x00\x00\x00', 'ucs2'), { readLength : new type.CallableValue(32) }),
 		keyboardType : new type.UInt32Le(KeyboardType.IBM_101_102_KEYS),
 		keyboardSubType : new type.UInt32Le(0),
 		keyboardFnKeys : new type.UInt32Le(12),
-		imeFileName : new type.BinaryString(new Buffer(Array(64 + 1).join('\x00')), { readLength : new type.CallableValue(64), optional : true }),
+		imeFileName : new type.BinaryString(Buffer.alloc(64), { readLength : new type.CallableValue(64), optional : true }),
 		postBeta2ColorDepth : new type.UInt16Le(ColorDepth.RNS_UD_COLOR_8BPP, { optional : true }),
 		clientProductId : new type.UInt16Le(1, { optional : true }),
 		serialNumber : new type.UInt32Le(0, { optional : true }),
 		highColorDepth : new type.UInt16Le(HighColor.HIGH_COLOR_24BPP, { optional : true }),
 		supportedColorDepths : new type.UInt16Le(Support.RNS_UD_15BPP_SUPPORT | Support.RNS_UD_16BPP_SUPPORT | Support.RNS_UD_24BPP_SUPPORT | Support.RNS_UD_32BPP_SUPPORT, { optional : true }),
 		earlyCapabilityFlags : new type.UInt16Le(CapabilityFlag.RNS_UD_CS_SUPPORT_ERRINFO_PDU, { optional : true }),
-		clientDigProductId : new type.BinaryString(new Buffer(Array(64 + 1).join('\x00')), { optional : true, readLength : new type.CallableValue(64) }),
+		clientDigProductId : new type.BinaryString(Buffer.alloc(64), { optional : true, readLength : new type.CallableValue(64) }),
 		connectionType : new type.UInt8(0, { optional : true }),
 		pad1octet : new type.UInt8(0, { optional : true }),
 		serverSelectedProtocol : new type.UInt32Le(0, { optional : true })
@@ -502,7 +502,7 @@ function writeConferenceCreateRequest (userData) {
 	    per.writeLength(userData.size() + 14), per.writeChoice(0),
 	    per.writeSelection(0x08), per.writeNumericString("1", 1), per.writePadding(1),
 	    per.writeNumberOfSet(1), per.writeChoice(0xc0),
-	    per.writeOctetStream(new Buffer(h221_cs_key), 4), per.writeOctetStream(userDataStream.getValue())
+	    per.writeOctetStream(Buffer.from(h221_cs_key), 4), per.writeOctetStream(userDataStream.getValue())
     ]);
 }
 
@@ -515,7 +515,7 @@ function writeConferenceCreateResponse (userData) {
 	    per.writeLength(userData.size() + 14), per.writeChoice(0x14),
 	    per.writeInteger16(0x79F3, 1001), per.writeInteger(1), per.writeEnumerates(0),
 	    per.writeNumberOfSet(1), per.writeChoice(0xc0),
-	    per.writeOctetStream(new Buffer(h221_sc_key), 4), per.writeOctetStream(userDataStream.getValue())
+	    per.writeOctetStream(Buffer.from(h221_sc_key), 4), per.writeOctetStream(userDataStream.getValue())
     ]);
 }
 

--- a/lib/protocol/t125/mcs.js
+++ b/lib/protocol/t125/mcs.js
@@ -72,8 +72,8 @@ function DomainParameters(maxChannelIds, maxUserIds, maxTokenIds,
  */
 function ConnectInitial (userData) {
 	return new asn1.univ.Sequence({
-		callingDomainSelector : new asn1.univ.OctetString(new Buffer('\x01', 'binary')),
-		calledDomainSelector : new asn1.univ.OctetString(new Buffer('\x01', 'binary')),
+		callingDomainSelector : new asn1.univ.OctetString(Buffer.from('\x01', 'binary')),
+		calledDomainSelector : new asn1.univ.OctetString(Buffer.from('\x01', 'binary')),
 		upwardFlag : new asn1.univ.Boolean(true),
 		targetParameters : DomainParameters(34, 2, 0, 1, 0, 1, 0xffff, 2),
 		minimumParameters : DomainParameters(1, 1, 1, 1, 0, 1, 0x420, 2),

--- a/lib/protocol/t125/per.js
+++ b/lib/protocol/t125/per.js
@@ -263,7 +263,7 @@ function readPadding(s, length) {
  * @returns {type.BinaryString} per encoded padding
  */
 function writePadding(length) {
-    return new type.BinaryString(new Buffer(Array(length + 1).join("\x00")));
+    return new type.BinaryString(Buffer.alloc(length));
 }
 
 /**

--- a/lib/security/jsbn.js
+++ b/lib/security/jsbn.js
@@ -829,7 +829,7 @@ function bnToByteArray() {
  * @returns {Buffer}
  */
 function bnToBuffer(trimOrSize) {
-    var res = new Buffer(this.toByteArray());
+    var res = Buffer.from(this.toByteArray());
     if (trimOrSize === true && res[0] === 0) {
         res = res.slice(1);
     } else if (_.isNumber(trimOrSize)) {
@@ -841,7 +841,7 @@ function bnToBuffer(trimOrSize) {
             }
             return res.slice(res.length - trimOrSize);
         } else if (res.length < trimOrSize) {
-            var padded = new Buffer(trimOrSize);
+            var padded = Buffer.alloc(trimOrSize);
             padded.fill(0, 0, trimOrSize - res.length);
             res.copy(padded, trimOrSize - res.length);
             return padded;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,31 @@
+{
+  "name": "node-rdpjs",
+  "version": "0.3.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "node-rdpjs",
+      "version": "0.3.0",
+      "engines": [
+        "node >= 14.0.0"
+      ],
+      "license": "AGPL v3.0",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "starttls": "^1.0.1"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/starttls": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/starttls/-/starttls-1.0.1.tgz",
+      "integrity": "sha512-mfOPDJsq1GSvCyl6qQK5Slj486+6c2E/DJ3vo0TXs4kB+6xFBBuua2ngiudFyjpRYr9BIibsW9wn/5gl4EPaoA=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "Sylvain Peyrefitte",
   "version": "0.3.0",
   "engines": [
-    "node = 0.10.x"
+    "node >= 14.0.0"
   ],
   "description": "Remote Desktop Protocol in Node.js",
   "license": "AGPL v3.0",
@@ -13,7 +13,7 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "starttls": "^1.0.0",
-    "lodash": "3.3.0"
+    "starttls": "^1.0.1",
+    "lodash": "^4.17.21"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,44 @@
+const rdp = require('./lib/index.js');
+
+const options = {
+  domain: process.env.RDP_DOMAIN,
+  userName: process.env.RDP_USERNAME,
+  password: process.env.RDP_PASSWORD,
+  enablePerf: true,
+  autoLogin: true,
+  decompress: false,
+  screen: { width: 800, height: 600 },
+  locale: 'en',
+  logLevel: 'INFO'
+};
+
+const host = process.argv[2];
+const port = process.argv[3] || 3389;
+
+if (!host) {
+  console.error('Usage: node test.js <host> [port]');
+  process.exit(1);
+}
+
+console.log(`Connecting to ${host}:${port}...`);
+
+const client = rdp.createClient(options)
+  .on('connect', function () {
+    console.log('Successfully connected.');
+    process.exit(0);
+  })
+  .on('close', function() {
+    console.error('Connection closed.');
+    process.exit(1);
+  })
+  .on('error', function(err) {
+    console.error('Connection error:', err);
+    process.exit(1);
+  });
+
+client.connect(host, port);
+
+setTimeout(() => {
+  console.error('Connection timed out.');
+  process.exit(1);
+}, 15000); // 15 second timeout


### PR DESCRIPTION
- Replaced all deprecated `new Buffer()` calls with `Buffer.from()` or `Buffer.alloc()`.
- Updated `package.json` to require Node.js >= 14.0.0.
- Updated `lodash` and `starttls` dependencies to their latest versions.
- Added a `test.js` script for basic client functionality testing.